### PR TITLE
Making hatchery info optional for prepare_snppit_infile

### DIFF
--- a/R/prepare_snppit_infile.R
+++ b/R/prepare_snppit_infile.R
@@ -115,7 +115,7 @@ prepare_snppit_infile <- function(G,
   )
   #if hatchery information is not included
   if (hatchery == FALSE) {
-    dump <- write.table(select(x, -hatchery, -years_list, -min_year, -max_year),
+    dump <- write.table(select(Pars, -hatchery, -years_list, -min_year, -max_year),
                   row.names = FALSE,
                   col.names = FALSE,
                   quote = FALSE,

--- a/R/prepare_snppit_infile.R
+++ b/R/prepare_snppit_infile.R
@@ -19,6 +19,7 @@ prepare_snppit_infile <- function(G,
                                   min_age = 1,
                                   max_age = 6,
                                   geno_err = 0.005,
+                                  hatchery = TRUE,
                                   outf = tempfile()) {
 
   # these will get changed if we don't use them
@@ -112,7 +113,15 @@ prepare_snppit_infile <- function(G,
     file = outf,
     append = TRUE
   )
-
+  #if hatchery information is not included
+  if (hatchery == FALSE) {
+    dump <- write.table(select(x, -hatchery, -years_list, -min_year, -max_year),
+                  row.names = FALSE,
+                  col.names = FALSE,
+                  quote = FALSE,
+                  file = outf, append = TRUE, sep = "\t"
+      )
+  }
   # cycle over the different hatcheries that might be involved
   # and put in a block of parents for each
   dump <- lapply(split(Pars, Pars$hatchery), function(x) {


### PR DESCRIPTION
I tried to make the hatchery information optional. It still needs some work.The snppit file it makes without the hatchery info needs a POP name and I'm not sure how to add it. But, I thought we could get this pull request started and edit the code as needed. This way the default includes hatchery information, but there is an easy way to leave it out. 